### PR TITLE
Announce Claude Code notifications with a robot voice

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -19,6 +19,19 @@
       "serverUrl": "https://drivemcp.googleapis.com/*"
     }
   ],
+  "hooks": {
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "say --voice=Zarvox \"beep beep boop boop\"",
+            "async": true
+          }
+        ]
+      }
+    ]
+  },
   "statusLine": {
     "type": "command",
     "command": "bash ~/.config/claude/statusline-command.sh"


### PR DESCRIPTION
Adds a `Notification` hook to `claude/settings.json` that runs macOS `say` with the Zarvox voice when Claude Code needs input.

```json
"Notification": [
  { "hooks": [{ "type": "command",
                "command": "say --voice=Zarvox \"beep beep boop boop\"",
                "async": true }] }
]
```

- **Zarvox** picked after listening to all nine macOS novelty voices.
- No matcher, so it covers every notification type — permission prompts and idle-waiting-for-input.
- `async: true` so the speech never blocks the session.

## Verification

Confirmed firing end to end by temporarily instrumenting the hook to log its stdin payload and the `say` exit code:

```
"hook_event_name": "Notification"
"notification_type": "permission_prompt"
say exit=0
```

Worth knowing: the `Notification` event fires on a **delay** — Claude Code waits to see whether you respond before deciding you need alerting. Answering a prompt immediately preempts it, so the hook stays quiet while you are actively working and only speaks up once you have genuinely stopped paying attention. That is the intended behavior, but it does make the hook look dead if you test it by answering prompts right away.

https://claude.ai/code/session_0149a8zrhX55XCUwfFt9bgnt